### PR TITLE
Continuous integration builds for PRs to 'main'

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,0 +1,15 @@
+name: PR to main branch updated
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  Build-Test:
+    runs-on: ubuntu-latest
+    if: ${{ github.base_ref == 'main' }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: cargo build --release --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 .env
+.idea


### PR DESCRIPTION
If this is merged to the `main` branch, subsequent PRs against `main` will automatically trigger a CI build to verify everything compiles.

Should also run tests, but that involves setting up a [secret](https://docs.github.com/en/actions/reference/encrypted-secrets) for the API key.