### PR TITLE
Run tests as part of CI

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,4 +1,3 @@
-name: PR to main branch updated
 on:
   pull_request:
     types: [opened, synchronize]
@@ -7,9 +6,22 @@ jobs:
   Build-Test:
     runs-on: ubuntu-latest
     if: ${{ github.base_ref == 'main' }}
+    environment: build_test
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - run: cargo build --release --all-features
+
+      - name: Build all products
+        run: cargo build --release --all-features
+
+      - name: Run all tests
+        run: cargo test --all --release
+        # Testing requires adding a 'secret' to repo: https://docs.gitHub.com/en/actions/reference/encrypted-secrets
+        # Github -> Repo -> Settings Tab -> Environments -> New environment -> Create env secret for TEST_API_KEY
+        # New environment name must match the above environment name, since that's how environments are referenced.
+        env:
+          TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
+

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,8 @@
-use dotenv::dotenv;
-use std::env;
-
-#[allow(dead_code)]
+#[cfg(test)]
 pub fn get_test_api_key() -> String {
+    use dotenv::dotenv;
+    use std::env;
+
     dotenv().ok();
 
     let key = "TEST_API_KEY";


### PR DESCRIPTION
Run tests as part of CI.

This requires the following:
- Go to repository Settings -> Environment
- Create new environment with the name `build_test`
- Add an environment secret with the name `TEST_API_KEY` and set its value to your finnhub api key
- Do not specify any deployment branches. That way the environment can be available to all branches.

Also, when merging this, lets try a squash commit instead of a merge commit to see if the history looks any cleaner.