### PR TITLE
NaiveDate args for company_news

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde_derive = "1.0"
 strum = "0.20"
 strum_macros = "0.20"
 tokio = { version = "1.1", features = ["full"] }
+chrono = "0.4.28"
 
 [dev-dependencies]
 reqwest_mock = "0.7.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,6 +5,7 @@ use exitfailure::ExitFailure;
 use reqwest::Url;
 use crate::url_builder::UrlBuilder;
 use serde::de::DeserializeOwned;
+use chrono::NaiveDate;
 
 /// Finnhub API Client object.
 #[derive(Debug, Clone)]
@@ -81,15 +82,16 @@ impl Client {
     pub async fn company_news(
         &self,
         symbol: String,
-        from: String,
-        to: String,
+        from: NaiveDate,
+        to: NaiveDate,
     ) -> Result<(Vec<CompanyNews>, Url), ExitFailure> {
+        let fmt_str = "%Y-%m-%d".to_string();
         self.get::<Vec<CompanyNews>>(
             "company-news",
             &mut vec![
                 ("symbol", symbol),
-                ("from", from),
-                ("to", to),
+                ("from", from.format(&fmt_str).to_string()),
+                ("to", to.format(&fmt_str).to_string()),
             ]
         ).await
     }


### PR DESCRIPTION
Allows `company_news` to take NaiveDate arguments, clearing up possible confusion/user error when providing String args for dates.